### PR TITLE
Add 'completed' column to both tables

### DIFF
--- a/backend/prisma/migrations/20250814045546_add_completed_status_with_default/migration.sql
+++ b/backend/prisma/migrations/20250814045546_add_completed_status_with_default/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "BucketList" ADD COLUMN     "completed" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "BucketListItem" ADD COLUMN     "completed" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,9 +15,10 @@ datasource db {
 }
 
 model BucketList{
-  id        Int    @id @default(autoincrement())
+  id        Int      @id @default(autoincrement())
   location  String
   image     String?
+  completed Boolean  @default(false)
   userId    String
   item      BucketListItem[]
 }
@@ -27,6 +28,7 @@ model BucketListItem{
   city       String
   location   String
   food       String
+  completed  Boolean    @default(false)
   bucketList BucketList @relation(fields: [bucketId], references: [id])
   bucketId   Int
   userId     String


### PR DESCRIPTION
## Proposed changes

Add a 'completed' column with default value of false to BucketList and BucketListItem table schemas in order to keep track of Bucket List progress for each user.

Fixes-Bug: #55
Implements-Requirement: #55

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)